### PR TITLE
Jb 422 hyperparameter tuning additions

### DIFF
--- a/experiments/tuning/config.json
+++ b/experiments/tuning/config.json
@@ -1,0 +1,11 @@
+{
+    "description": "A simple experiment to exercise model tuning.",
+    "format_version": "0.3.0",
+    "timestamp": "2022-06-23T07:27:00",
+    "tuning":[
+        {
+            "model": "imagenette_160x160_rgb_unit_test_pyt_resnet18",
+            "tuning_config": "tuning/example_tuning_config.json"
+        }
+]
+}

--- a/tuning/example_tuning_config.json
+++ b/tuning/example_tuning_config.json
@@ -16,14 +16,15 @@
             ]
         }
     },
-    "search_space": {
-        "batch_size": {
+    "search_space": [
+        {
+            "hyperparameter_name": "batch_size",
             "fqcn": "ray.tune.choice",
             "kwargs": {
                 "categories": [10, 15, 20]
             }
         }
-    },
+    ],
     "timestamp": "2022-06-14T09:00:00",
     "trial_resources": {
         "cpu": 8,

--- a/tuning/example_tuning_config.json
+++ b/tuning/example_tuning_config.json
@@ -10,9 +10,9 @@
         "fqcn": "ray.tune.suggest.basic_variant.BasicVariantGenerator",
         "kwargs": {
             "points_to_evaluate": [
+                {"batch_size": 20},
                 {"batch_size": 10},
-                {"batch_size": 15},
-                {"batch_size": 20}
+                {"batch_size": 15}
             ]
         }
     },

--- a/tuning/example_tuning_config.json
+++ b/tuning/example_tuning_config.json
@@ -23,6 +23,15 @@
             "kwargs": {
                 "categories": [10, 15, 20]
             }
+        },
+        {
+            "hyperparameter_name": "pytorch.lr_schedule_args.gamma",
+            "fqcn": "ray.tune.quniform",
+            "kwargs": {
+                "lower": 0.5,
+                "upper": 1.0,
+                "q": 0.1
+            }
         }
     ],
     "timestamp": "2022-06-14T09:00:00",

--- a/tuning/example_tuning_config.json
+++ b/tuning/example_tuning_config.json
@@ -1,0 +1,32 @@
+{
+    "description": "An example tuning config for tuning imagenette_160x160_rgb_unit_test_pyt_resnet18",
+    "format_version": "0.1.0",
+    "sample_quantity": 3,
+    "scheduler": {
+        "fqcn": "ray.tune.schedulers.AsyncHyperBandScheduler",
+        "kwargs": {}
+    },
+    "search_algorithm": {
+        "fqcn": "ray.tune.suggest.basic_variant.BasicVariantGenerator",
+        "kwargs": {}
+    },
+    "search_space": {
+        "batch_size": {
+            "fqcn": "ray.tune.choice",
+            "kwargs": {
+                "categories": [10, 15, 20]
+            }
+        }
+    },
+    "timestamp": "2022-06-14T09:00:00",
+    "trial_resources": {
+        "cpu": 8,
+        "gpu": 0
+    },
+    "tuning_parameters": {
+        "checkpoint_interval": 1,
+        "metric": "loss",
+        "mode": "min",
+        "scope": "last"
+    }
+}

--- a/tuning/example_tuning_config.json
+++ b/tuning/example_tuning_config.json
@@ -1,7 +1,7 @@
 {
     "description": "An example tuning config for tuning imagenette_160x160_rgb_unit_test_pyt_resnet18",
     "format_version": "0.1.0",
-    "sample_quantity": 3,
+    "num_samples": 3,
     "scheduler": {
         "fqcn": "ray.tune.schedulers.AsyncHyperBandScheduler",
         "kwargs": {}

--- a/tuning/example_tuning_config.json
+++ b/tuning/example_tuning_config.json
@@ -8,7 +8,13 @@
     },
     "search_algorithm": {
         "fqcn": "ray.tune.suggest.basic_variant.BasicVariantGenerator",
-        "kwargs": {}
+        "kwargs": {
+            "points_to_evaluate": [
+                {"batch_size": 10},
+                {"batch_size": 15},
+                {"batch_size": 20}
+            ]
+        }
     },
     "search_space": {
         "batch_size": {


### PR DESCRIPTION
This PR is a companion PR to PR#112 in the juneberry repo. 

This PR contains an example tuning config that can be used to exercise a simple hyperparameter tuning run on the PyTorch imagenette model. Also included is an experiment config file that will exercise the tuning feature.