### PR TITLE
Edit to vignette experiment outline for reports compatibility

### DIFF
--- a/docs/vignettes/vignette1/configs/experiment_outline.json
+++ b/docs/vignettes/vignette1/configs/experiment_outline.json
@@ -5,8 +5,8 @@
     "reports": [
         {
             "description": "Experiment Summary",
-            "output_name": "Experiment Summary.md",
-            "type": "summary"
+            "fqcn": "juneberry.reporting.summary.Summary",
+            "kwargs": {}
         }
     ],
     "tests": [


### PR DESCRIPTION
Small update to the vignette's example experiment outline file so that the Summary Report will function properly.