### PR TITLE
Jb 490 vignette update sept 2022

### DIFF
--- a/docs/vignettes/vignette1/Replicating_a_Classic_Machine_Learning_Result_with_Juneberry.md
+++ b/docs/vignettes/vignette1/Replicating_a_Classic_Machine_Learning_Result_with_Juneberry.md
@@ -460,8 +460,7 @@ As a time-saving convenience, a pre-built model architecture file is available a
 
 `docs/vignettes/vignette1/configs/resnet_simple.py`
 
-If you do not wish to create your own model architecture file from scratch, you can simply move or copy the 
-pre-built file to the target location (juneberry_example_workspace/architectures/pytorch/resnet_simple.py).
+This is also copied (conveniently) at `juneberry_example_workspace/architectures/pytorch/resnet_simple.py`.
 
 ## Implementing the training strategy outlined in a paper with a Juneberry model config.
 

--- a/models/tabular_multiclass_sample/config.json
+++ b/models/tabular_multiclass_sample/config.json
@@ -19,6 +19,12 @@
     },
     "seed": 4210592948,
     "timestamp": "2021-03-01T10:00:00",
+    "trainer":{
+	    "fqcn":"juneberry.pytorch.trainer.ClassifierTrainer"
+    },
+    "evaluator":{
+        "fqcn":"juneberry.pytorch.evaluation.evaluator.Evaluator"
+    },
     "training_dataset_config_path": "models/tabular_multiclass_sample/train_data_config.json",
     "validation": {
         "algorithm": "from_file",


### PR DESCRIPTION
Very minor changes to vignette based on running in September 2022. It turns out most of my issues were from running the wrong docker container and using an older version of Juneberry (at first). Primarily adding this to go through the process.