### PR TITLE
Update to run_system_test.py

### DIFF
--- a/models/text_detect/mmd/ut/config.json
+++ b/models/text_detect/mmd/ut/config.json
@@ -44,7 +44,8 @@
         "load_from": "https://download.openmmlab.com/mmdetection/v2.0/faster_rcnn/faster_rcnn_r50_caffe_dc5_mstrain_1x_coco/faster_rcnn_r50_caffe_dc5_mstrain_1x_coco_20201028_233851-b33d21b9.pth",
         "overrides": {
             "model.roi_head.bbox_head.num_classes": 3,
-            "optimizer.lr": 0.003
+            "optimizer.lr": 0.003,
+            "device": "cuda"
         }
     },
     "model_architecture": {

--- a/scripts/run_system_test.py
+++ b/scripts/run_system_test.py
@@ -955,8 +955,8 @@ def main():
         logging.error("Reinit and initifneeded may not be set at the same time. Exiting.")
         sys.exit(-1)
 
-    if args.threshold >= 100 or args.threshold <= -100:
-        logging.error("Threshold to compare results must be below 100 and above -100. Exiting.")
+    if args.threshold >= 100:
+        logging.error("Threshold to compare results must be below 100. Exiting.")
         sys.exit(-1)
 
     if args.reinit:

--- a/scripts/run_system_test.py
+++ b/scripts/run_system_test.py
@@ -955,8 +955,8 @@ def main():
         logging.error("Reinit and initifneeded may not be set at the same time. Exiting.")
         sys.exit(-1)
 
-    if args.threshold < 100:
-        logging.error("Threshold to compare results must be below 100. Exiting.")
+    if args.threshold >= 100 or args.threshold < 0:
+        logging.error("Threshold to compare results must be below 100 and greater/equal to 0. Exiting.")
         sys.exit(-1)
 
     if args.reinit:

--- a/scripts/run_system_test.py
+++ b/scripts/run_system_test.py
@@ -920,7 +920,7 @@ def main():
                              "Incompatible with init.")
     parser.add_argument("--initifneeded", default=False, action="store_true",
                         help="Set to true to automatically init if not inited. Incompatible with init or reinit.")
-    parser.add_argument("--threshold", type=int, default=20,
+    parser.add_argument("--threshold", type=int, default=0,
                         help="Sets the threshold to be used when comparing the difference between the known/latest results.")
     args = parser.parse_args()
 

--- a/scripts/run_system_test.py
+++ b/scripts/run_system_test.py
@@ -232,6 +232,7 @@ def compare_test_results(model_mgr: jbfs.ModelManager, threshold: int, error_sum
     """
     Compares the latest results to the known results in the model directory.
     :param model_mgr: The model dir
+    :param threshold: The maximum percentage difference used to compare results
     :param error_summary: A summary of generated errors
     :return: 0 if no errors, 1 if an error
     """
@@ -263,11 +264,11 @@ def compare_test_results(model_mgr: jbfs.ModelManager, threshold: int, error_sum
             return 1
 
         # Check if results are within a threshold of eachother
-        diff = ((known_results - latest_results) / known_results) * 100
-        if diff > threshold or diff < (-1 * threshold):
-            logging.error(f">>> Unit test FAILED. 'Results from known and latest are more than 10% different' <<<")
+        diff = abs(((known_results - latest_results) / known_results) * 100)
+        if diff > threshold:
+            logging.error(f">>> Unit test FAILED. 'Results from known and latest are more than {threshold}% different' <<<")
             error_summary.append(
-                f">>> Unit test FAILED. 'Results from known and latest are more than 10% different' <<<")
+                f">>> Unit test FAILED. 'Results from known and latest are more than {threshold}% different' <<<")
             return 1
         else:
             logging.info(f">>> Successful results for for {model_mgr.get_model_dir()} <<<")

--- a/scripts/run_system_test.py
+++ b/scripts/run_system_test.py
@@ -955,7 +955,7 @@ def main():
         logging.error("Reinit and initifneeded may not be set at the same time. Exiting.")
         sys.exit(-1)
 
-    if args.threshold >= 100:
+    if args.threshold < 100:
         logging.error("Threshold to compare results must be below 100. Exiting.")
         sys.exit(-1)
 


### PR DESCRIPTION
**Dec 19 2022**

Summary: 
Updated the run_system_test to now allow for a difference between the results of the `known_results.json` and `latest_results.json` by a certain threshold. The unit test now checks for the classification/object detection results from both of these files and then calculates the percentage difference between the results (accuracy/mAP). If the percentage difference exceeds the threshold percentage set by the user (default value set to 0%) the unit test will fail. We previously checked by doing a `diff` between these two files. Given we are seeing some variation, we need to look into new heuristics for comparison and verification.

This update was inspired from updating to the newest NVIDIA Pytorch 22.11 and seeing varying results in our `known` and `latest`.

Files changes:
`scripts/run_system_test.py`